### PR TITLE
Update site to work in "archive mode"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,10 +3,25 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import icon from "astro-icon";
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
+
+const ARCHIVE_MODE = process.env.ARCHIVE_MODE === "true";
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), react(), mdx(), icon(), sitemap()],
-  site: "https://www.mitmysteryheist.com",
+  site: ARCHIVE_MODE ? "https://puzzles.mit.edu/2025/heist/" : "https://www.mitmysteryheist.com",
+  base: ARCHIVE_MODE ? "/2025/heist/" : "/",
+  experimental: {
+    env: {
+      schema: {
+        ARCHIVE_MODE: envField.boolean({
+          context: "client",
+          access: "public",
+          optional: true,
+          default: false,
+        }),
+      },
+    },
+  },
 });

--- a/src/components/AnswerSubmission.tsx
+++ b/src/components/AnswerSubmission.tsx
@@ -1,6 +1,9 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 
+
+
 import { checkAnswer } from "@/lib/checker";
+import localStoragePrefix from "@/lib/localStoragePrefix";
 import { cleanInputAnswer } from "@/lib/utils";
 
 interface AnswerSubmissionProps {
@@ -26,11 +29,14 @@ export default function AnswerSubmission({
   encoded_keep_going,
   slug,
 }: AnswerSubmissionProps) {
-  const [history, setHistory] = useLocalStorage<[string, string][]>(`${slug}_history`, []);
+  const [history, setHistory] = useLocalStorage<[string, string][]>(
+    `${localStoragePrefix}${slug}_history`,
+    [],
+  );
 
   const solved =
-    localStorage.getItem(`${slug}_solution`) !== `""` &&
-    localStorage.getItem(`${slug}_solution`) !== null;
+    localStorage.getItem(`${localStoragePrefix}${slug}_solution`) !== `""` &&
+    localStorage.getItem(`${localStoragePrefix}${slug}_solution`) !== null;
 
   const onSubmitHandler: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
@@ -62,7 +68,7 @@ export default function AnswerSubmission({
           </button>
           <a
             className="rounded-[.3rem] bg-gray-500 px-4 py-2 text-white font-semibold hover:bg-gray-600 transition"
-            href={`/solutions/${slug}`}
+            href={`${import.meta.env.BASE_URL}solutions/${slug}`}
           >
             Solution
           </a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,7 +8,7 @@ const { title } = Astro.props;
 
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />
   <meta name="viewport" content="width=device-width" />
   <meta name="generator" content={Astro.generator} />
   <title>{title}</title>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -8,8 +8,8 @@ import logo_black from "@/assets/landing/logo-black1.png";
 <nav
   class={`sticky top-0 flex items-center p-2 px-4  ${dark ? "text-white" : "text-black bg-white/35"}`}
 >
-  <!-- <a href="/" class="font-mono text-lg font-bold">MIT Mystery Heist</a> -->
-  <a href="/">
+  <!-- <a href={import.meta.env.BASE_URL} class="font-mono text-lg font-bold">MIT Mystery Heist</a> -->
+  <a href={import.meta.env.BASE_URL}>
     <img
       src={dark ? logo_white.src : logo_black.src}
       class=`h-[4.5rem] transition duration-300 ease-in-out hover:cursor-pointer
@@ -19,7 +19,7 @@ import logo_black from "@/assets/landing/logo-black1.png";
 
   <div class="flex-1"></div>
   <div class="flex items-center gap-10 pr-0 sm:pr-10">
-    <a href="/puzzles" class="text-center text-xl font-bold">Puzzles</a>
+    <a href={`${import.meta.env.BASE_URL}puzzles`} class="text-center text-xl font-bold">Puzzles</a>
   </div>
 </nav>
 

--- a/src/components/PuzzleIndexItem.astro
+++ b/src/components/PuzzleIndexItem.astro
@@ -1,9 +1,11 @@
 ---
+import localStoragePrefix from "@/lib/localStoragePrefix";
+
 const { puz } = Astro.props;
-const solution = localStorage.getItem(`${puz.slug}_solution`)
+const solution = localStorage.getItem(`${localStoragePrefix}${puz.slug}_solution`)
 ---
 <div id="puzindex-{name}">
-  <a href="{puz.slug}"><b>{puz.title}</b></a>
+  <a href={`${import.meta.env.BASE_URL}{puz.slug}`}><b>{puz.title}</b></a>
   { solution && <p><br>{solution}</p> }
 </div>
   

--- a/src/components/react/CountdownTimer.tsx
+++ b/src/components/react/CountdownTimer.tsx
@@ -51,7 +51,7 @@ const CountdownTimer: React.FC<CountdownTimerProps> = ({ targetDate, endText, cl
         </p>
       ) : (
         <a
-          href="/puzzles"
+          href={`${import.meta.env.BASE_URL}puzzles`}
           className="px-4 py-2 font-bold rounded-md transition-all duration-300 ease-in-out hover:border-white hover:drop-shadow-[0_0_10px_rgba(255,255,255,0.4)] hover:text-[4rem]"
         >
           LET'S HEIST!!

--- a/src/components/react/ModePicker.tsx
+++ b/src/components/react/ModePicker.tsx
@@ -1,11 +1,13 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 
+import localStoragePrefix from "@/lib/localStoragePrefix";
+
 import ModePickDialog from "./ModePickDialog";
 import ResetProgressDialog from "./ResetProgressDialog";
 import StoryDialog from "./StoryDialog";
 
 function ModePicker() {
-  const [isExpert, setisExpert] = useLocalStorage("puzzle-mode", true);
+  const [isExpert, setisExpert] = useLocalStorage(`${localStoragePrefix}puzzle-mode`, true);
 
   return (
     <div className="flex flex-wrap justify-center items-center gap-2 py-4 space-x-2">

--- a/src/components/react/PacketView.tsx
+++ b/src/components/react/PacketView.tsx
@@ -1,10 +1,13 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { useState } from "react";
 
+
+
 import clipboard from "@/assets/puzzles-page/clipboard.png";
 import clipboard_expert from "@/assets/puzzles-page/clipboard_expert.png";
 import dvd1 from "@/assets/puzzles-page/dvd_1.png";
 import dvd2 from "@/assets/puzzles-page/dvd_2.png";
+import localStoragePrefix from "@/lib/localStoragePrefix";
 import { PacketSlug, PuzzleDifficulty } from "@/lib/types";
 
 import PasswordDialog from "./PasswordProtectDialog";
@@ -36,35 +39,37 @@ function generatePDFLink(
   difficulty: PuzzleDifficulty,
   slug: PacketSlug,
 ): string {
-  return !isMobile ? `/packets/${difficulty}/${slug}` : GOOGLE_DRIVE_MIRRORS[difficulty][slug];
+  return !isMobile
+    ? `${import.meta.env.BASE_URL}packets/${difficulty}/${slug}`
+    : GOOGLE_DRIVE_MIRRORS[difficulty][slug];
 }
 
 export default function PacketView() {
   const isMobile = import.meta.env.SSR ? false : window.innerWidth <= 768;
 
-  const [isExpert, _setisExpert] = useLocalStorage("puzzle-mode", true);
+  const [isExpert, _setisExpert] = useLocalStorage(`${localStoragePrefix}puzzle-mode`, true);
   const difficulty: PuzzleDifficulty = isExpert ? PuzzleDifficulty.Expert : PuzzleDifficulty.Casual;
 
-  // console.log(localStorage.getItem(`casual/${META_1_SLUG}_solution`));
-  // console.log(localStorage.getItem(`casual/${META_1_SLUG}_solution`) !== `""`);
+  // console.log(localStorage.getItem(`${localStoragePrefix}casual/${META_1_SLUG}_solution`));
+  // console.log(localStorage.getItem(`${localStoragePrefix}casual/${META_1_SLUG}_solution`) !== `""`);
 
   const packet1MetaSolved =
-    (localStorage.getItem(`casual/${META_1_SLUG}_solution`) !== `""` &&
-      localStorage.getItem(`casual/${META_1_SLUG}_solution`)) ||
-    (localStorage.getItem(`expert/${META_1_SLUG}_solution`) !== `""` &&
-      localStorage.getItem(`expert/${META_1_SLUG}_solution`));
+    (localStorage.getItem(`${localStoragePrefix}casual/${META_1_SLUG}_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}casual/${META_1_SLUG}_solution`)) ||
+    (localStorage.getItem(`${localStoragePrefix}expert/${META_1_SLUG}_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}expert/${META_1_SLUG}_solution`));
 
   const packet2MetaSolved =
-    (localStorage.getItem(`casual/${META_2_SLUG}_solution`) !== `""` &&
-      localStorage.getItem(`casual/${META_2_SLUG}_solution`)) ||
-    (localStorage.getItem(`expert/${META_2_SLUG}_solution`) !== `""` &&
-      localStorage.getItem(`expert/${META_2_SLUG}_solution`));
+    (localStorage.getItem(`${localStoragePrefix}casual/${META_2_SLUG}_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}casual/${META_2_SLUG}_solution`)) ||
+    (localStorage.getItem(`${localStoragePrefix}expert/${META_2_SLUG}_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}expert/${META_2_SLUG}_solution`));
 
   const huntSolved =
-    (localStorage.getItem(`casual/supermeta_solution`) !== `""` &&
-      localStorage.getItem(`casual/supermeta_solution`)) ||
-    (localStorage.getItem(`expert/supermeta_solution`) !== `""` &&
-      localStorage.getItem(`expert/supermeta_solution`));
+    (localStorage.getItem(`${localStoragePrefix}casual/supermeta_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}casual/supermeta_solution`)) ||
+    (localStorage.getItem(`${localStoragePrefix}expert/supermeta_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}expert/supermeta_solution`));
 
   const [showPacket2Modal, setShowPacket2Modal] = useState(false);
   const [showSupermetaModal, setShowSuperMetaModal] = useState(false);
@@ -90,7 +95,7 @@ export default function PacketView() {
       <div className="flex flex-wrap items-center justify-center gap-10 sm:flex-nowrap sm:space-y-0 space-y-2">
         <div className="flex basis-full justify-center sm:basis-1/2 relative">
           <div className="flex flex-col items-center">
-            <a href={`/puzzles/packet1`}>
+            <a href={`${import.meta.env.BASE_URL}puzzles/packet1`}>
               <img
                 className="h-[24rem] max-w-max transition-transform duration-300 hover:scale-105 hover:drop-shadow-[0_4px_15px_rgba(0,0,0,0.6)]"
                 src={dvd1.src}
@@ -125,7 +130,7 @@ export default function PacketView() {
                 className="px-4 py-2 bg-gray-100 text-white rounded-[0.3rem]"
                 href={
                   packet2MetaSolved
-                    ? `/puzzles/${difficulty}/supermeta`
+                    ? `${import.meta.env.BASE_URL}puzzles/${difficulty}/supermeta`
                     : "#"
                 }
                 onClick={handleSupermetaClick}
@@ -167,7 +172,10 @@ export default function PacketView() {
           className={`flex basis-full justify-center sm:basis-1/2 relative order-5 ${!packet1MetaSolved && "blur-[10px]"}`}
         >
           <div className="flex flex-col items-center">
-            <a href={packet1MetaSolved ? `/puzzles/packet2` : "#"} onClick={handlePacket2Click}>
+            <a
+              href={packet1MetaSolved ? `${import.meta.env.BASE_URL}puzzles/packet2` : "#"}
+              onClick={handlePacket2Click}
+            >
               <img
                 className="h-[24rem] max-w-max  transition-transform duration-300 hover:scale-105 hover:drop-shadow-[0_4px_15px_rgba(0,0,0,0.6)]"
                 src={dvd2.src}
@@ -199,7 +207,7 @@ export default function PacketView() {
           <a
             className="mt-4 text-xl rounded-xl border-4 border-[#63268a99] px-4 py-2 font-mono font-bold blur-[0.5px] transition-all duration-300 ease-in-out hover:scale-105 hover:border-[#63268aff] hover:drop-shadow-[0_0_10px_rgba(0,0,0,0.3)]
         px-4 py-2 rounded-[0.3rem] order-7"
-            href="/Conclusion.pdf"
+            href={`${import.meta.env.BASE_URL}Conclusion.pdf`}
           >
             📖 CONCLUSION 📖
           </a>

--- a/src/components/react/PasswordProtectDialog.tsx
+++ b/src/components/react/PasswordProtectDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
+import localStoragePrefix from "@/lib/localStoragePrefix";
 import { cleanInputAnswer } from "@/lib/utils";
 
 interface PasswordDialogProps {
@@ -60,8 +61,8 @@ const PasswordDialog: React.FC<PasswordDialogProps> = ({
 
     if (result.isValid) {
       setFeedback(null);
-      localStorage.setItem(`casual/${slug}_solution`, correctPassword);
-      localStorage.setItem(`expert/${slug}_solution`, correctPassword);
+      localStorage.setItem(`${localStoragePrefix}casual/${slug}_solution`, correctPassword);
+      localStorage.setItem(`${localStoragePrefix}expert/${slug}_solution`, correctPassword);
       closeModal();
     } else {
       setFeedback(result.message);

--- a/src/components/react/PuzzleIndex.tsx
+++ b/src/components/react/PuzzleIndex.tsx
@@ -1,6 +1,9 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 import type { CollectionEntry } from "astro:content";
 
+
+
+import localStoragePrefix from "@/lib/localStoragePrefix";
 import { PuzzleDifficulty, type PuzzlePacket } from "@/lib/types";
 import { filterPuzzleCollection } from "@/lib/utils";
 
@@ -12,7 +15,7 @@ interface PuzzleIndexProps {
 }
 
 function PuzzleIndex({ puzzles, packet }: PuzzleIndexProps) {
-  const [isExpert, setisExpert] = useLocalStorage("puzzle-mode", true);
+  const [isExpert, setisExpert] = useLocalStorage(`${localStoragePrefix}puzzle-mode`, true);
   const difficulty: PuzzleDifficulty = isExpert ? PuzzleDifficulty.Expert : PuzzleDifficulty.Casual;
   const puzzlesRendered = packet
     ? filterPuzzleCollection(puzzles, difficulty, packet)
@@ -27,7 +30,7 @@ function PuzzleIndex({ puzzles, packet }: PuzzleIndexProps) {
           return (
             <a
               key={puzzle.slug}
-              href={`/puzzles/${puzzle.slug}`}
+              href={`${import.meta.env.BASE_URL}puzzles/${puzzle.slug}`}
               className={`flex group justify-between items-center py-4 ${
                 isLastItem ? "font-bold text-gray-800" : ""
               }`}

--- a/src/components/react/PuzzleIndexItem.tsx
+++ b/src/components/react/PuzzleIndexItem.tsx
@@ -1,13 +1,17 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 import type { CollectionEntry } from "astro:content";
 
+
+
+import localStoragePrefix from "@/lib/localStoragePrefix";
+
 interface PuzzleIndexItemProps {
   puzzle: CollectionEntry<"puzzle">;
   isMeta: boolean;
 }
 
 function PuzzleIndexItem({ puzzle, isMeta }: PuzzleIndexItemProps) {
-  const solution = localStorage.getItem(`${puzzle.slug}_solution`);
+  const solution = localStorage.getItem(`${localStoragePrefix}${puzzle.slug}_solution`);
 
   return (
     <>

--- a/src/components/react/ResetProgressDialog.tsx
+++ b/src/components/react/ResetProgressDialog.tsx
@@ -1,3 +1,5 @@
+import { ARCHIVE_MODE } from "astro:env/client";
+
 import {
   Dialog,
   DialogContent,
@@ -6,10 +8,22 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import localStoragePrefix from "@/lib/localStoragePrefix";
 
 const resetProgress = () => {
   console.log("clearing site progress!!!");
-  localStorage.clear();
+  if (ARCHIVE_MODE) {
+    // Only reset keys with the localStoragePrefix
+    const keysToClear = Object.keys(localStorage).filter((key) =>
+      key.startsWith(localStoragePrefix),
+    );
+    keysToClear.forEach((key) => {
+      localStorage.removeItem(key);
+    });
+  } else {
+    // On the mitmysteryheist.com site, we can just nuke all local storage
+    localStorage.clear();
+  }
   window.location.reload();
 };
 

--- a/src/components/react/StoryDialog.tsx
+++ b/src/components/react/StoryDialog.tsx
@@ -1,18 +1,17 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { useEffect } from "react";
 
+
+
 import art from "@/assets/art/story.png";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import localStoragePrefix from "@/lib/localStoragePrefix";
 
 const StoryDialog = () => {
-  const [hasSeenStory, setHasSeenStory] = useLocalStorage("has-seen-story", false);
+  const [hasSeenStory, setHasSeenStory] = useLocalStorage(
+    `${localStoragePrefix}has-seen-story`,
+    false,
+  );
 
   useEffect(() => {
     if (!hasSeenStory) {

--- a/src/content/packet/casual/packet-1.mdx
+++ b/src/content/packet/casual/packet-1.mdx
@@ -2,4 +2,4 @@
 slug: casual/packet-1
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
-<embed src="/Round 1 - Casual.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Round 1 - Casual.pdf`} class="w-screen h-screen"/>

--- a/src/content/packet/casual/packet-2.mdx
+++ b/src/content/packet/casual/packet-2.mdx
@@ -2,4 +2,4 @@
 slug: casual/packet-2
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
-<embed src="/Round 2 - Casual.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Round 2 - Casual.pdf`} class="w-screen h-screen"/>

--- a/src/content/packet/casual/supermeta.mdx
+++ b/src/content/packet/casual/supermeta.mdx
@@ -2,4 +2,4 @@
 slug: casual/supermeta
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
-<embed src="/Supermeta - Casual.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Supermeta - Casual.pdf`} class="w-screen h-screen"/>

--- a/src/content/packet/expert/packet-1.mdx
+++ b/src/content/packet/expert/packet-1.mdx
@@ -2,4 +2,4 @@
 slug: expert/packet-1
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
-<embed src="/Round 1 - Expert.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Round 1 - Expert.pdf`} class="w-screen h-screen"/>

--- a/src/content/packet/expert/packet-2.mdx
+++ b/src/content/packet/expert/packet-2.mdx
@@ -3,4 +3,4 @@ slug: expert/packet-2
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
 
-<embed src="/Round 2 - Expert.pdf" class="h-screen w-screen" />
+<embed src={`${import.meta.env.BASE_URL}Round 2 - Expert.pdf`} class="h-screen w-screen" />

--- a/src/content/packet/expert/supermeta.mdx
+++ b/src/content/packet/expert/supermeta.mdx
@@ -2,4 +2,4 @@
 slug: expert/supermeta
 layout: "@/layouts/BaseLayoutWithoutNav.astro"
 ---
-<embed src="/Supermeta - Expert.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Supermeta - Expert.pdf`} class="w-screen h-screen"/>

--- a/src/content/puzzle/casual/packet1/benny-panoply.mdx
+++ b/src/content/puzzle/casual/packet1/benny-panoply.mdx
@@ -17,7 +17,7 @@ import art from "@/assets/art/1.1 benny's panoply.png"
 <div class="flex flex-col sm:flex-row gap-2 justify-between items-center">
 <div class="flex flex-col">
 # Benny&#39;s Panoply
-<a href="/Appendix A Printable.pdf" class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
+<a href={`${import.meta.env.BASE_URL}Appendix A Printable.pdf`} class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
   <svg className="w-4"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M128 0C92.7 0 64 28.7 64 64l0 96 64 0 0-96 226.7 0L384 93.3l0 66.7 64 0 0-66.7c0-17-6.7-33.3-18.7-45.3L400 18.7C388 6.7 371.7 0 354.7 0L128 0zM384 352l0 32 0 64-256 0 0-64 0-16 0-16 256 0zm64 32l32 0c17.7 0 32-14.3 32-32l0-96c0-35.3-28.7-64-64-64L64 192c-35.3 0-64 28.7-64 64l0 96c0 17.7 14.3 32 32 32l32 0 0 64c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-64zM432 248a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
   <span>Items to Print</span>
 </a>

--- a/src/content/puzzle/casual/packet2/cracking-the-safe.mdx
+++ b/src/content/puzzle/casual/packet2/cracking-the-safe.mdx
@@ -14,7 +14,7 @@ import art from "@/assets/art/cracking-transp.png"
 <div class="flex flex-col sm:flex-row gap-2 justify-between items-center">
 <div class="flex flex-col">
 # Cracking the Safe
-<a href="/Appendix C Printable.pdf" class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
+<a href={`${import.meta.env.BASE_URL}Appendix C Printable.pdf`} class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
   <svg className="w-4"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M128 0C92.7 0 64 28.7 64 64l0 96 64 0 0-96 226.7 0L384 93.3l0 66.7 64 0 0-66.7c0-17-6.7-33.3-18.7-45.3L400 18.7C388 6.7 371.7 0 354.7 0L128 0zM384 352l0 32 0 64-256 0 0-64 0-16 0-16 256 0zm64 32l32 0c17.7 0 32-14.3 32-32l0-96c0-35.3-28.7-64-64-64L64 192c-35.3 0-64 28.7-64 64l0 96c0 17.7 14.3 32 32 32l32 0 0 64c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-64zM432 248a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
   <span>Items to Print</span>
 </a>
@@ -28,6 +28,6 @@ work. Stethoscope in hand, he turns the dials and tries to crack the combo.
 The bank manager once boasted that this vault was uncrackable. What didn't he anticipate?
 </div>
 
-<img src="/Cracking-1.png"></img>
-<img src="/Cracking-2.png"></img>
-<img src="/Cracking-3.png"></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-1.png`}></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-2.png`}></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-3.png`}></img>

--- a/src/content/puzzle/casual/packet2/nola.mdx
+++ b/src/content/puzzle/casual/packet2/nola.mdx
@@ -22,7 +22,7 @@ import art from "@/assets/art/nola-transp.png"
   post-heist celebration would be similar as well…
 </div>
 
-<img src="/NOLA.png" class="aspect-square"></img>
+<img src={`${import.meta.env.BASE_URL}NOLA.png`} class="aspect-square"></img>
 
 ## To-Do
 

--- a/src/content/puzzle/casual/packet2/unfolding-futures.mdx
+++ b/src/content/puzzle/casual/packet2/unfolding-futures.mdx
@@ -13,7 +13,7 @@ import art from "@/assets/art/unfolding-transp.png"
 <div class="flex flex-col sm:flex-row gap-2 justify-between items-center">
 <div class="flex flex-col">
 # Unfolding Future
-<a href="/Appendix B Printable - Casual.pdf" class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
+<a href={`${import.meta.env.BASE_URL}Appendix B Printable - Casual.pdf`} class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
   <svg className="w-4"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M128 0C92.7 0 64 28.7 64 64l0 96 64 0 0-96 226.7 0L384 93.3l0 66.7 64 0 0-66.7c0-17-6.7-33.3-18.7-45.3L400 18.7C388 6.7 371.7 0 354.7 0L128 0zM384 352l0 32 0 64-256 0 0-64 0-16 0-16 256 0zm64 32l32 0c17.7 0 32-14.3 32-32l0-96c0-35.3-28.7-64-64-64L64 192c-35.3 0-64 28.7-64 64l0 96c0 17.7 14.3 32 32 32l32 0 0 64c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-64zM432 248a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
   <span>Items to Print</span>
 </a>
@@ -25,7 +25,7 @@ import art from "@/assets/art/unfolding-transp.png"
 <div class="italics" style={{fontFamily: "DM Mono, sans-serif"}}>Before the heist, Benny seeks help to see how the
 future will unfold. Whom does he consult?</div>
 
-<img src="/unfolding_future.png"> </img>
-<img src="/unfolding_future_casual.png"> </img>
+<img src={`${import.meta.env.BASE_URL}unfolding_future.png`}> </img>
+<img src={`${import.meta.env.BASE_URL}unfolding_future_casual.png`}> </img>
 
-<a href="/Unfolding-Future-Casual.pdf">PDF For Printing</a>
+<a href={`${import.meta.env.BASE_URL}Unfolding-Future-Casual.pdf`}>PDF For Printing</a>

--- a/src/content/puzzle/expert/packet1/benny-panoply.mdx
+++ b/src/content/puzzle/expert/packet1/benny-panoply.mdx
@@ -17,7 +17,7 @@ import art from "@/assets/art/1.1 benny's panoply.png"
 <div class="flex flex-col sm:flex-row gap-2 justify-between items-center">
 <div class="flex flex-col">
 # Benny&#39;s Panoply
-<a href="/Appendix A Printable.pdf" class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
+<a href={`${import.meta.env.BASE_URL}Appendix A Printable.pdf`} class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
   <svg className="w-4"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M128 0C92.7 0 64 28.7 64 64l0 96 64 0 0-96 226.7 0L384 93.3l0 66.7 64 0 0-66.7c0-17-6.7-33.3-18.7-45.3L400 18.7C388 6.7 371.7 0 354.7 0L128 0zM384 352l0 32 0 64-256 0 0-64 0-16 0-16 256 0zm64 32l32 0c17.7 0 32-14.3 32-32l0-96c0-35.3-28.7-64-64-64L64 192c-35.3 0-64 28.7-64 64l0 96c0 17.7 14.3 32 32 32l32 0 0 64c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-64zM432 248a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
   <span>Items to Print</span>
 </a>

--- a/src/content/puzzle/expert/packet2/cracking-the-safe.mdx
+++ b/src/content/puzzle/expert/packet2/cracking-the-safe.mdx
@@ -13,7 +13,7 @@ import art from "@/assets/art/cracking-transp.png"
 <div class="flex flex-col sm:flex-row gap-2 justify-between items-center">
 <div class="flex flex-col">
 # Cracking the Safe
-<a href="/Appendix C Printable.pdf" class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
+<a href={`${import.meta.env.BASE_URL}Appendix C Printable.pdf`} class="w-fit flex gap-2 no-prose h-min no-underline bg-gray-500 text-white px-4 py-2 rounded-[0.3rem]">
   <svg className="w-4"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M128 0C92.7 0 64 28.7 64 64l0 96 64 0 0-96 226.7 0L384 93.3l0 66.7 64 0 0-66.7c0-17-6.7-33.3-18.7-45.3L400 18.7C388 6.7 371.7 0 354.7 0L128 0zM384 352l0 32 0 64-256 0 0-64 0-16 0-16 256 0zm64 32l32 0c17.7 0 32-14.3 32-32l0-96c0-35.3-28.7-64-64-64L64 192c-35.3 0-64 28.7-64 64l0 96c0 17.7 14.3 32 32 32l32 0 0 64c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-64zM432 248a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
   <span>Items to Print</span>
 </a>
@@ -27,6 +27,6 @@ work. Stethoscope in hand, he turns the dials and tries to crack the combo.
 The bank manager once boasted that this vault was uncrackable. What didn't he anticipate?_
 </div>
 
-<img src="/Cracking-1.png"></img>
-<img src="/Cracking-2.png"></img>
-<img src="/Cracking-3.png"></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-1.png`}></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-2.png`}></img>
+<img src={`${import.meta.env.BASE_URL}Cracking-3.png`}></img>

--- a/src/content/puzzle/expert/packet2/nola.mdx
+++ b/src/content/puzzle/expert/packet2/nola.mdx
@@ -23,7 +23,7 @@ import art from "@/assets/art/nola-transp.png"
   post-heist celebration would be similar as well…
 </div>
 
-<img src="/NOLA.png" class="aspect-square"></img>
+<img src={`${import.meta.env.BASE_URL}NOLA.png`} class="aspect-square"></img>
 
 ## To-Do
 

--- a/src/content/puzzle/expert/packet2/unfolding-futures.mdx
+++ b/src/content/puzzle/expert/packet2/unfolding-futures.mdx
@@ -15,7 +15,7 @@ import art from "@/assets/art/unfolding-transp.png";
   <div class="flex flex-col">
     # Unfolding Future
     <a
-      href="/Appendix B Printable - Expert.pdf"
+      href={`${import.meta.env.BASE_URL}Appendix B Printable - Expert.pdf`}
       class="no-prose flex h-min w-fit gap-2 rounded-[0.3rem] bg-gray-500 px-4 py-2 text-white no-underline"
     >
       <svg className="w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -34,5 +34,5 @@ import art from "@/assets/art/unfolding-transp.png";
   Before the heist, Benny seeks help to see how the future will unfold. Whom does he consult?
 </div>
 
-<img src="/unfolding_future.png"> </img>
-<img src="/unfolding_future_expert.png"> </img>
+<img src={`${import.meta.env.BASE_URL}unfolding_future.png`}> </img>
+<img src={`${import.meta.env.BASE_URL}unfolding_future_expert.png`}> </img>

--- a/src/content/solution/casual/benny-panoply.mdx
+++ b/src/content/solution/casual/benny-panoply.mdx
@@ -2,4 +2,4 @@
 slug: casual/benny-panoply
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Benny's Panoply (solution).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Benny's Panoply (solution).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/cracking-the-safe.mdx
+++ b/src/content/solution/casual/cracking-the-safe.mdx
@@ -2,4 +2,4 @@
 slug: casual/cracking
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Cracking_the_Safe.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Cracking_the_Safe.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/detour-de-force.mdx
+++ b/src/content/solution/casual/detour-de-force.mdx
@@ -3,4 +3,4 @@ slug: casual/supermeta
 layout: "@/layouts/BaseLayout.astro"
 ---
 
-<embed src="/Solution-Detour_de_Force.pdf" class="h-screen w-screen" />
+<embed src={`${import.meta.env.BASE_URL}Solution-Detour_de_Force.pdf`} class="h-screen w-screen" />

--- a/src/content/solution/casual/financial-planning.mdx
+++ b/src/content/solution/casual/financial-planning.mdx
@@ -3,4 +3,4 @@ slug: casual/financial-planning
 layout: "@/layouts/BaseLayout.astro"
 ---
 
-<embed src="/Solution-Financial_Planning.pdf" class="h-screen w-screen" />
+<embed src={`${import.meta.env.BASE_URL}Solution-Financial_Planning.pdf`} class="h-screen w-screen" />

--- a/src/content/solution/casual/how-to-be-presentable.mdx
+++ b/src/content/solution/casual/how-to-be-presentable.mdx
@@ -2,4 +2,4 @@
 slug: casual/presentable
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-How_to_Be_Presentable(Casual).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-How_to_Be_Presentable(Casual).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/interview-questions.mdx
+++ b/src/content/solution/casual/interview-questions.mdx
@@ -2,4 +2,4 @@
 slug: casual/interview
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Interview_Questions.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Interview_Questions.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/nadine-connection.mdx
+++ b/src/content/solution/casual/nadine-connection.mdx
@@ -2,4 +2,4 @@
 slug: casual/nadine-connection
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Nadine's Connections (Casual_Expert).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Nadine's Connections (Casual_Expert).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/nola.mdx
+++ b/src/content/solution/casual/nola.mdx
@@ -2,4 +2,4 @@
 slug: casual/nola
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-NOLA.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-NOLA.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/rover-escape.mdx
+++ b/src/content/solution/casual/rover-escape.mdx
@@ -2,4 +2,4 @@
 slug: casual/rover-escape
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Rover's Escape Plans.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Rover's Escape Plans.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/sidecar-blueprint.mdx
+++ b/src/content/solution/casual/sidecar-blueprint.mdx
@@ -2,4 +2,4 @@
 slug: casual/sidecar-blueprint
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Sidecar's Blueprints.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Sidecar's Blueprints.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/team-building-exercise.mdx
+++ b/src/content/solution/casual/team-building-exercise.mdx
@@ -2,4 +2,4 @@
 slug: casual/building
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Team-Building Exercise (Casual_Expert).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Team-Building Exercise (Casual_Expert).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/casual/unfolding-futures.mdx
+++ b/src/content/solution/casual/unfolding-futures.mdx
@@ -2,4 +2,4 @@
 slug: casual/unfolding
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Unfolding_Futures.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Unfolding_Futures.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/benny-panoply.mdx
+++ b/src/content/solution/expert/benny-panoply.mdx
@@ -2,4 +2,4 @@
 slug: expert/benny-panoply
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Benny's Panoply (solution).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Benny's Panoply (solution).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/cracking-the-safe.mdx
+++ b/src/content/solution/expert/cracking-the-safe.mdx
@@ -2,4 +2,4 @@
 slug: expert/cracking
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Cracking_the_Safe.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Cracking_the_Safe.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/detour-de-force.mdx
+++ b/src/content/solution/expert/detour-de-force.mdx
@@ -3,4 +3,4 @@ slug: expert/supermeta
 layout: "@/layouts/BaseLayout.astro"
 ---
 
-<embed src="/Solution-Detour_de_Force.pdf" class="h-screen w-screen" />
+<embed src={`${import.meta.env.BASE_URL}Solution-Detour_de_Force.pdf`} class="h-screen w-screen" />

--- a/src/content/solution/expert/financial-planning.mdx
+++ b/src/content/solution/expert/financial-planning.mdx
@@ -3,4 +3,4 @@ slug: expert/financial-planning
 layout: "@/layouts/BaseLayout.astro"
 ---
 
-<embed src="/Solution-Financial_Planning.pdf" class="h-screen w-screen" />
+<embed src={`${import.meta.env.BASE_URL}Solution-Financial_Planning.pdf`} class="h-screen w-screen" />

--- a/src/content/solution/expert/how-to-be-presentable.mdx
+++ b/src/content/solution/expert/how-to-be-presentable.mdx
@@ -2,4 +2,4 @@
 slug: expert/presentable
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-How_to_Be_Presentable(Expert).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-How_to_Be_Presentable(Expert).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/interview-questions.mdx
+++ b/src/content/solution/expert/interview-questions.mdx
@@ -2,4 +2,4 @@
 slug: expert/interview
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Interview_Questions.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Interview_Questions.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/nadine-connection.mdx
+++ b/src/content/solution/expert/nadine-connection.mdx
@@ -2,4 +2,4 @@
 slug: expert/nadine-connection
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Nadine's Connections (Casual_Expert).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Nadine's Connections (Casual_Expert).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/nola.mdx
+++ b/src/content/solution/expert/nola.mdx
@@ -2,4 +2,4 @@
 slug: expert/nola
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-NOLA.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-NOLA.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/rover-escape.mdx
+++ b/src/content/solution/expert/rover-escape.mdx
@@ -2,4 +2,4 @@
 slug: expert/rover-escape
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Rover's Escape Plans.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Rover's Escape Plans.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/sidecar-blueprint.mdx
+++ b/src/content/solution/expert/sidecar-blueprint.mdx
@@ -2,4 +2,4 @@
 slug: expert/sidecar-blueprint
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Sidecar's Blueprints.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Sidecar's Blueprints.pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/team-building-exercise.mdx
+++ b/src/content/solution/expert/team-building-exercise.mdx
@@ -2,4 +2,4 @@
 slug: expert/building
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution - Team-Building Exercise (Casual_Expert).pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution - Team-Building Exercise (Casual_Expert).pdf`} class="w-screen h-screen"/>

--- a/src/content/solution/expert/unfolding-futures.mdx
+++ b/src/content/solution/expert/unfolding-futures.mdx
@@ -2,4 +2,4 @@
 slug: expert/unfolding
 layout: "@/layouts/BaseLayout.astro"
 ---
-<embed src="/Solution-Unfolding_Futures.pdf" class="w-screen h-screen"/>
+<embed src={`${import.meta.env.BASE_URL}Solution-Unfolding_Futures.pdf`} class="w-screen h-screen"/>

--- a/src/lib/checker.js
+++ b/src/lib/checker.js
@@ -1,3 +1,6 @@
+import localStoragePrefix from "@/lib/localStoragePrefix";
+
+
 // Configuration (to be set by the site owner)
 const encodedAnswers = ["Y29ycmVjdEFuc3dlcg=="]; // Base64 encoded correct answers
 const keepGoingPhrases = {
@@ -24,14 +27,14 @@ export function checkAnswer(
   const statusDiv = document.getElementById("status");
   let responseMessage = "";
 
-  // console.log(localStorage.getItem(`${slug}_solution`));
-  // console.log(localStorage.getItem(`${slug}_solution`) !== "");
+  // console.log(localStorage.getItem(`${localStoragePrefix}${slug}_solution`));
+  // console.log(localStorage.getItem(`${localStoragePrefix}${slug}_solution`) !== "");
 
   if (
     userAnswer == "" ||
     !enabled ||
-    (localStorage.getItem(`${slug}_solution`) !== `""` &&
-      localStorage.getItem(`${slug}_solution`) !== null)
+    (localStorage.getItem(`${localStoragePrefix}${slug}_solution`) !== `""` &&
+      localStorage.getItem(`${localStoragePrefix}${slug}_solution`) !== null)
   ) {
     return;
   }
@@ -49,7 +52,7 @@ export function checkAnswer(
   const uppercaseAnswer = userAnswer.toUpperCase();
   if (atob(encodedAnswer) === uppercaseAnswer) {
     responseMessage = "✅";
-    localStorage.setItem(`${slug}_solution`, uppercaseAnswer);
+    localStorage.setItem(`${localStoragePrefix}${slug}_solution`, uppercaseAnswer);
   } else if (!responseMessage) {
     responseMessage = "❌";
   }

--- a/src/lib/localStoragePrefix.ts
+++ b/src/lib/localStoragePrefix.ts
@@ -1,0 +1,3 @@
+import { ARCHIVE_MODE } from "astro:env/client";
+
+export default ARCHIVE_MODE ? "heist2025_" : "";


### PR DESCRIPTION
When built or run with the environment variable `ARCHIVE_MODE` set to "true", the site will mount itself under the `/2025/heist/` (with the expected hostname of `puzzles.mit.edu`).

The changes to support this look somewhat extensive, but mostly consist of prefixing all URLs with `import.meta.env.BASE_URL`. These replacements should be exhaustive (I'm pretty sure I found any string that started with `/`), although it's certainly possible I missed something.

Since puzzles.mit.edu is a shared space, I also added a prefix to localStorage keys (when `ARCHIVE_MODE` is enabled) to avoid collisions with other archived hunts.

All of these changes should be noops when `ARCHIVE_MODE` is not set, allowing the site to continue running normally on the mitmysteryheist.com domain.